### PR TITLE
fix: ensure auth implementation is initialized correctly

### DIFF
--- a/template/client/src/graphql/client.ts
+++ b/template/client/src/graphql/client.ts
@@ -2,7 +2,7 @@ import { DataSyncConfig, OfflineClient } from '@aerogear/voyager-client';
 import { Auth } from '@aerogear/auth';
 import { AeroGearApp } from '@aerogear/app';
 
-export const createClient = (auth: Auth, app: AeroGearApp) => {
+export const createClient = (auth: Auth | undefined, app: AeroGearApp) => {
 
     const syncConfigs = app.config && app.config.getConfigByType('sync-app')
 

--- a/template/client/src/index.tsx
+++ b/template/client/src/index.tsx
@@ -7,12 +7,13 @@ import 'semantic-ui-css/semantic.min.css'
 import App from './App';
 import { createClient } from "./graphql/client";
 import './index.css';
-import { auth, withAuth } from './services/auth.service'
+import { getAuth, withAuth } from './services/auth.service'
 import * as serviceWorker from './serviceWorker';
 
 
 import mobileConfig from './mobile-services.json'
 const app = init(mobileConfig as unknown as AeroGearConfiguration)
+const auth = getAuth(app)
 
 // tslint:disable-next-line: no-floating-promises
 createClient(auth, app).then((client) => {
@@ -22,8 +23,7 @@ createClient(auth, app).then((client) => {
             <ApolloProvider client={client}>
                 <App />
             </ApolloProvider>
-        , app)
-        , document.getElementById('root'));
+        ), document.getElementById('root'));
 })
 
 

--- a/template/client/src/services/auth.service.tsx
+++ b/template/client/src/services/auth.service.tsx
@@ -9,18 +9,18 @@ const LoadingComponent = () => <h2>Loading...</h2>
 
 let auth
 
-export const withAuth = (children: ReactNode, app: AeroGearApp) => {
-    if (!app.config) {
-        return children
-    }
-    const appConfig: ConfigurationService = app.config;
-    const authConfig = appConfig.getConfigByType(Auth.TYPE) as ServiceConfiguration[]
+export const getAuth = (app: AeroGearApp): Auth | undefined => {
+    const appConfig = app.config as ConfigurationService;
+    const authConfig = appConfig.getConfigByType(Auth.TYPE) as ServiceConfiguration[];
 
-    let auth
     if (authConfig.length > 0) {
         auth = new Auth(appConfig)
+        return auth
     }
+}
 
+
+export const withAuth = (children: ReactNode) => {
     if (auth) {
         return (
             <KeycloakProvider keycloak={auth.extract()} initConfig={{ onLoad: 'login-required' }} LoadingComponent={LoadingComponent()}>
@@ -30,5 +30,3 @@ export const withAuth = (children: ReactNode, app: AeroGearApp) => {
     }
     return children
 }
-
-export { auth }


### PR DESCRIPTION
#8 actually kinda broke things. This one ensures the auth implementation is set up properly. You can verify that by checking that the keycloak authorization header is actually sent with the GraphQL requests.